### PR TITLE
Add grouping by name

### DIFF
--- a/src/demo/pages/App_Group.js
+++ b/src/demo/pages/App_Group.js
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import TimeLine from 'libs/TimeLine';
+import Generator from './Generator';
+import './App.css';
+
+class App extends Component {
+  constructor(props) {
+    super(props);
+    let d1 = new Date();
+    let d2 = new Date();
+    d2.setDate(d2.getDate() + 5);
+    let d3 = new Date();
+    d3.setDate(d3.getDate() + 8);
+    let d4 = new Date();
+    d4.setDate(d4.getDate() + 20);
+    this.data = [
+      { id: 1, start: d1, end: d2, name: 'Demo Task 1', groupName: 'Group 1' },
+      {
+        id: 2,
+        start: d3,
+        end: d4,
+        name: 'Demo Task 2',
+        groupName: 'Group 1'
+      }
+    ];
+    this.links = [{ id: 1, start: 1, end: 2 }];
+  }
+
+  render() {
+    return (
+      <div className="app-container">
+        <h1>Getting Started Demo</h1>
+        {/* DayWidth<input type="range" min="30" max="500" value={this.state.daysWidth} onChange={this.handleDayWidth} step="1"/>
+           Item Height<input type="range" min="30" max="500" value={this.state.itemheight} onChange={this.handleItemHeight} step="1"/> */}
+        <div className="time-line-container">
+          <TimeLine data={this.data} links={this.links} />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default App;

--- a/src/lib/TimeLine.js
+++ b/src/lib/TimeLine.js
@@ -264,7 +264,7 @@ class TimeLine extends Component {
   onFinishCreateLink = (task, position) => {
     console.log(`End Link ${task}`);
     if (this.props.onCreateLink && task &&
-      this.state.taskToCreate &&this.state.taskToCreate.task.id!=task.id) {
+      this.state.taskToCreate && this.state.taskToCreate.task.id != task.id) {
       this.props.onCreateLink({
         start: this.state.taskToCreate,
         end: { task: task, position: position }
@@ -303,16 +303,18 @@ class TimeLine extends Component {
     }
   }
   checkNeeeData = () => {
+    let groupByName = this.props.config && this.props.config.dataViewPort && this.props.config.dataViewPort.groupByName;
+
     if (this.props.data != this.state.data) {
       this.state.data = this.props.data;
       let rowInfo = this.calculateStartEndRows(this.state.numVisibleRows, this.props.data, this.state.scrollTop);
       this.state.startRow = rowInfo.start;
       this.state.endRow = rowInfo.end;
-      Registry.registerData(this.state.data);
+      Registry.registerData(this.state.data, groupByName);
     }
     if (this.props.links != this.state.links) {
       this.state.links = this.props.links;
-      Registry.registerLinks(this.props.links);
+      Registry.registerLinks(this.props.links, groupByName);
     }
   };
   render() {

--- a/src/lib/TimeLine.js
+++ b/src/lib/TimeLine.js
@@ -303,18 +303,16 @@ class TimeLine extends Component {
     }
   }
   checkNeeeData = () => {
-    let groupByName = this.props.config && this.props.config.dataViewPort && this.props.config.dataViewPort.groupByName;
-
     if (this.props.data != this.state.data) {
       this.state.data = this.props.data;
       let rowInfo = this.calculateStartEndRows(this.state.numVisibleRows, this.props.data, this.state.scrollTop);
       this.state.startRow = rowInfo.start;
       this.state.endRow = rowInfo.end;
-      Registry.registerData(this.state.data, groupByName);
+      Registry.registerData(this.state.data);
     }
     if (this.props.links != this.state.links) {
       this.state.links = this.props.links;
-      Registry.registerLinks(this.props.links, groupByName);
+      Registry.registerLinks(this.props.links);
     }
   };
   render() {

--- a/src/lib/components/taskList/TaskList.js
+++ b/src/lib/components/taskList/TaskList.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import Config from 'libs/helpers/config/Config';
 import ContentEditable from 'libs/components/common/ContentEditable';
-import DateHelper from 'libs/helpers/DateHelper';
+import Registry from 'libs/helpers/registry/Registry';
 
 export class VerticalLine extends Component {
   constructor(props) {
@@ -59,44 +59,14 @@ export default class TaskList extends Component {
 
   renderTaskRow(data) {
     let result = [];
-    if (Config.data.dataViewPort.groupByName) {
-      const groups = {};
-      for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
-        let item = this.props.data[i];
-        if (!item) break;
-        if (groups[item.name] !== undefined) {
-          groups[item.name].push(item);
-        } else {
-          groups[item.name] = [item];
-        }
-      }
-      Object.keys(groups).forEach((key, i) => {
-        const group = groups[key]
-        group.forEach(item => {
-          result.push(
-            <TaskRow
-              key={i + item.id}
-              index={item.name + i}
-              item={item}
-              label={item.name}
-              top={i * this.props.itemheight}
-              itemheight={this.props.itemheight}
-              isSelected={this.props.selectedItem == item}
-              onUpdateTask={this.props.onUpdateTask}
-              onSelectItem={this.props.onSelectItem}
-              nonEditable={this.props.nonEditable}
-            />
-          );
-        });
-      });
-    } else {
-      for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
-        let item = data[i];
-        if (!item) break;
+    const groups = Registry.groupData(data, this.props.startRow, this.props.endRow + 1);
+    Object.keys(groups).forEach((key, i) => {
+      const group = groups[key];
+      group.forEach(item => {
         result.push(
           <TaskRow
-            key={i}
-            index={i}
+            key={i + item.id}
+            index={item.name + i}
             item={item}
             label={item.name}
             top={i * this.props.itemheight}
@@ -107,8 +77,8 @@ export default class TaskList extends Component {
             nonEditable={this.props.nonEditable}
           />
         );
-      }
-    }
+      });
+    });
     return result;
   }
 

--- a/src/lib/components/taskList/TaskList.js
+++ b/src/lib/components/taskList/TaskList.js
@@ -68,7 +68,7 @@ export default class TaskList extends Component {
             key={i + item.id}
             index={item.name + i}
             item={item}
-            label={item.name}
+            label={key}
             top={i * this.props.itemheight}
             itemheight={this.props.itemheight}
             isSelected={this.props.selectedItem == item}

--- a/src/lib/components/taskList/TaskList.js
+++ b/src/lib/components/taskList/TaskList.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import Config from 'libs/helpers/config/Config';
 import ContentEditable from 'libs/components/common/ContentEditable';
+import DateHelper from 'libs/helpers/DateHelper';
 
 export class VerticalLine extends Component {
   constructor(props) {
@@ -39,8 +40,8 @@ export class TaskRow extends Component {
             {this.props.label}
           </div>
         ) : (
-          <ContentEditable value={this.props.label} index={this.props.index} onChange={this.onChange} />
-        )}
+            <ContentEditable value={this.props.label} index={this.props.index} onChange={this.onChange} />
+          )}
       </div>
     );
   }
@@ -58,23 +59,55 @@ export default class TaskList extends Component {
 
   renderTaskRow(data) {
     let result = [];
-    for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
-      let item = data[i];
-      if (!item) break;
-      result.push(
-        <TaskRow
-          key={i}
-          index={i}
-          item={item}
-          label={item.name}
-          top={i * this.props.itemheight}
-          itemheight={this.props.itemheight}
-          isSelected={this.props.selectedItem == item}
-          onUpdateTask={this.props.onUpdateTask}
-          onSelectItem={this.props.onSelectItem}
-          nonEditable={this.props.nonEditable}
-        />
-      );
+    if (Config.data.dataViewPort.groupByName) {
+      const groups = {};
+      for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
+        let item = this.props.data[i];
+        if (!item) break;
+        if (groups[item.name] !== undefined) {
+          groups[item.name].push(item);
+        } else {
+          groups[item.name] = [item];
+        }
+      }
+      Object.keys(groups).forEach((key, i) => {
+        const group = groups[key]
+        group.forEach(item => {
+          result.push(
+            <TaskRow
+              key={i + item.id}
+              index={item.name + i}
+              item={item}
+              label={item.name}
+              top={i * this.props.itemheight}
+              itemheight={this.props.itemheight}
+              isSelected={this.props.selectedItem == item}
+              onUpdateTask={this.props.onUpdateTask}
+              onSelectItem={this.props.onSelectItem}
+              nonEditable={this.props.nonEditable}
+            />
+          );
+        });
+      });
+    } else {
+      for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
+        let item = data[i];
+        if (!item) break;
+        result.push(
+          <TaskRow
+            key={i}
+            index={i}
+            item={item}
+            label={item.name}
+            top={i * this.props.itemheight}
+            itemheight={this.props.itemheight}
+            isSelected={this.props.selectedItem == item}
+            onUpdateTask={this.props.onUpdateTask}
+            onSelectItem={this.props.onSelectItem}
+            nonEditable={this.props.nonEditable}
+          />
+        );
+      }
     }
     return result;
   }

--- a/src/lib/components/viewport/DataViewPort.js
+++ b/src/lib/components/viewport/DataViewPort.js
@@ -4,6 +4,7 @@ import DataTask from 'libs/components/viewport/DataTask';
 import DateHelper from 'libs/helpers/DateHelper';
 import sizeMe from 'react-sizeme';
 import Config from 'libs/helpers/config/Config';
+import Registry from 'libs/helpers/registry/Registry';
 
 export class DataRow extends Component {
   constructor(props) {
@@ -36,84 +37,41 @@ export class DataViewPort extends Component {
 
   renderRows = () => {
     let result = [];
-    if (Config.data.dataViewPort.groupByName) {
-      const groups = {};
-      for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
-        let item = this.props.data[i];
-        if (!item) break;
-        if (groups[item.name] !== undefined) {
-          groups[item.name].push(item);
-        } else {
-          groups[item.name] = [item];
-        }
-      }
-      Object.keys(groups).forEach((key, i) => {
-        const group = groups[key]
-        result.push(
-          <DataRow key={key} label={key} top={i * this.props.itemheight} left={20} itemheight={this.props.itemheight}>
-            {
-              group.map(item => {
-                let new_position = DateHelper.dateToPixel(item.start, this.props.nowposition, this.props.dayWidth);
-                let new_width = DateHelper.dateToPixel(item.end, this.props.nowposition, this.props.dayWidth) - new_position;
-                return <DataTask
-                  key={item.id}
-                  item={item}
-                  label={item.name}
-                  nowposition={this.props.nowposition}
-                  dayWidth={this.props.dayWidth}
-                  color={item.color}
-                  left={new_position}
-                  width={new_width}
-                  height={this.props.itemheight}
-                  onChildDrag={this.onChildDrag}
-                  isSelected={this.props.selectedItem == item}
-                  onSelectItem={this.props.onSelectItem}
-                  onStartCreateLink={this.props.onStartCreateLink}
-                  onFinishCreateLink={this.props.onFinishCreateLink}
-                  onTaskChanging={this.props.onTaskChanging}
-                  onUpdateTask={this.props.onUpdateTask}
-                >
-                  {' '}
-                </DataTask>
-              })
-            }
-          </DataRow>
-        );
-      });
-    } else {
-      for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
-        let item = this.props.data[i];
-        if (!item) break;
-        //FIXME PAINT IN BOUNDARIES
+    const groups = Registry.groupData(this.props.data, this.props.startRow, this.props.endRow + 1);
 
-        let new_position = DateHelper.dateToPixel(item.start, this.props.nowposition, this.props.dayWidth);
-        let new_width = DateHelper.dateToPixel(item.end, this.props.nowposition, this.props.dayWidth) - new_position;
-        result.push(
-          <DataRow key={i} label={item.name} top={i * this.props.itemheight} left={20} itemheight={this.props.itemheight}>
-            <DataTask
-              item={item}
-              label={item.name}
-              nowposition={this.props.nowposition}
-              dayWidth={this.props.dayWidth}
-              color={item.color}
-              left={new_position}
-              width={new_width}
-              height={this.props.itemheight}
-              onChildDrag={this.onChildDrag}
-              isSelected={this.props.selectedItem == item}
-              onSelectItem={this.props.onSelectItem}
-              onStartCreateLink={this.props.onStartCreateLink}
-              onFinishCreateLink={this.props.onFinishCreateLink}
-              onTaskChanging={this.props.onTaskChanging}
-              onUpdateTask={this.props.onUpdateTask}
-            >
-              {' '}
-            </DataTask>
-          </DataRow>
-        );
-      }
-    }
-
+    Object.keys(groups).forEach((key, i) => {
+      const group = groups[key];
+      result.push(
+        <DataRow key={key} label={key} top={i * this.props.itemheight} left={20} itemheight={this.props.itemheight}>
+          {
+            group.map(item => {
+              let new_position = DateHelper.dateToPixel(item.start, this.props.nowposition, this.props.dayWidth);
+              let new_width = DateHelper.dateToPixel(item.end, this.props.nowposition, this.props.dayWidth) - new_position;
+              return <DataTask
+                key={item.id}
+                item={item}
+                label={item.name}
+                nowposition={this.props.nowposition}
+                dayWidth={this.props.dayWidth}
+                color={item.color}
+                left={new_position}
+                width={new_width}
+                height={this.props.itemheight}
+                onChildDrag={this.onChildDrag}
+                isSelected={this.props.selectedItem == item}
+                onSelectItem={this.props.onSelectItem}
+                onStartCreateLink={this.props.onStartCreateLink}
+                onFinishCreateLink={this.props.onFinishCreateLink}
+                onTaskChanging={this.props.onTaskChanging}
+                onUpdateTask={this.props.onUpdateTask}
+              >
+                {' '}
+              </DataTask>
+            })
+          }
+        </DataRow>
+      );
+    });
     return result;
   };
 

--- a/src/lib/components/viewport/DataViewPort.js
+++ b/src/lib/components/viewport/DataViewPort.js
@@ -36,37 +36,84 @@ export class DataViewPort extends Component {
 
   renderRows = () => {
     let result = [];
-    for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
-      let item = this.props.data[i];
-      if (!item) break;
-      //FIXME PAINT IN BOUNDARIES
+    if (Config.data.dataViewPort.groupByName) {
+      const groups = {};
+      for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
+        let item = this.props.data[i];
+        if (!item) break;
+        if (groups[item.name] !== undefined) {
+          groups[item.name].push(item);
+        } else {
+          groups[item.name] = [item];
+        }
+      }
+      Object.keys(groups).forEach((key, i) => {
+        const group = groups[key]
+        result.push(
+          <DataRow key={key} label={key} top={i * this.props.itemheight} left={20} itemheight={this.props.itemheight}>
+            {
+              group.map(item => {
+                let new_position = DateHelper.dateToPixel(item.start, this.props.nowposition, this.props.dayWidth);
+                let new_width = DateHelper.dateToPixel(item.end, this.props.nowposition, this.props.dayWidth) - new_position;
+                return <DataTask
+                  key={item.id}
+                  item={item}
+                  label={item.name}
+                  nowposition={this.props.nowposition}
+                  dayWidth={this.props.dayWidth}
+                  color={item.color}
+                  left={new_position}
+                  width={new_width}
+                  height={this.props.itemheight}
+                  onChildDrag={this.onChildDrag}
+                  isSelected={this.props.selectedItem == item}
+                  onSelectItem={this.props.onSelectItem}
+                  onStartCreateLink={this.props.onStartCreateLink}
+                  onFinishCreateLink={this.props.onFinishCreateLink}
+                  onTaskChanging={this.props.onTaskChanging}
+                  onUpdateTask={this.props.onUpdateTask}
+                >
+                  {' '}
+                </DataTask>
+              })
+            }
+          </DataRow>
+        );
+      });
+    } else {
+      for (let i = this.props.startRow; i < this.props.endRow + 1; i++) {
+        let item = this.props.data[i];
+        if (!item) break;
+        //FIXME PAINT IN BOUNDARIES
 
-      let new_position = DateHelper.dateToPixel(item.start, this.props.nowposition, this.props.dayWidth);
-      let new_width = DateHelper.dateToPixel(item.end, this.props.nowposition, this.props.dayWidth) - new_position;
-      result.push(
-        <DataRow key={i} label={item.name} top={i * this.props.itemheight} left={20} itemheight={this.props.itemheight}>
-          <DataTask
-            item={item}
-            label={item.name}
-            nowposition={this.props.nowposition}
-            dayWidth={this.props.dayWidth}
-            color={item.color}
-            left={new_position}
-            width={new_width}
-            height={this.props.itemheight}
-            onChildDrag={this.onChildDrag}
-            isSelected={this.props.selectedItem == item}
-            onSelectItem={this.props.onSelectItem}
-            onStartCreateLink={this.props.onStartCreateLink}
-            onFinishCreateLink={this.props.onFinishCreateLink}
-            onTaskChanging={this.props.onTaskChanging}
-            onUpdateTask={this.props.onUpdateTask}
-          >
-            {' '}
-          </DataTask>
-        </DataRow>
-      );
+        let new_position = DateHelper.dateToPixel(item.start, this.props.nowposition, this.props.dayWidth);
+        let new_width = DateHelper.dateToPixel(item.end, this.props.nowposition, this.props.dayWidth) - new_position;
+        result.push(
+          <DataRow key={i} label={item.name} top={i * this.props.itemheight} left={20} itemheight={this.props.itemheight}>
+            <DataTask
+              item={item}
+              label={item.name}
+              nowposition={this.props.nowposition}
+              dayWidth={this.props.dayWidth}
+              color={item.color}
+              left={new_position}
+              width={new_width}
+              height={this.props.itemheight}
+              onChildDrag={this.onChildDrag}
+              isSelected={this.props.selectedItem == item}
+              onSelectItem={this.props.onSelectItem}
+              onStartCreateLink={this.props.onStartCreateLink}
+              onFinishCreateLink={this.props.onFinishCreateLink}
+              onTaskChanging={this.props.onTaskChanging}
+              onUpdateTask={this.props.onUpdateTask}
+            >
+              {' '}
+            </DataTask>
+          </DataRow>
+        );
+      }
     }
+
     return result;
   };
 

--- a/src/lib/helpers/config/Config.js
+++ b/src/lib/helpers/config/Config.js
@@ -55,7 +55,8 @@ const defvalues = {
       }
     }
   },
-  dataViewPort: {
+  dataViewPort: {    
+    groupByName: false,
     rows: {
       style: {
         backgroundColor: '#fbf9f9',

--- a/src/lib/helpers/config/Config.js
+++ b/src/lib/helpers/config/Config.js
@@ -56,7 +56,6 @@ const defvalues = {
     }
   },
   dataViewPort: {    
-    groupByName: false,
     rows: {
       style: {
         backgroundColor: '#fbf9f9',

--- a/src/lib/helpers/registry/Registry.js
+++ b/src/lib/helpers/registry/Registry.js
@@ -1,47 +1,85 @@
-
-class Registry{
-    constructor(){
-        this.data={}
-        this.link={}
+class Registry {
+    constructor() {
+        this.data = {}
+        this.link = {}
     }
 
-    registerData(list){
+    registerData(list, groupByName) {
         if (!list)
             return;
-        this.data={}
-        for (let i=0;i<list.length;i++){
-            this.data[list[i].id]={item:list[i],index:i};
+        this.data = {}
+        if (groupByName) {
+            const groups = {};
+            for (let i = 0; i < list.length; i++) {
+                let item = list[i];
+                if (!item) break;
+                if (groups[item.name] !== undefined) {
+                    groups[item.name].push(item);
+                } else {
+                    groups[item.name] = [item];
+                }
+            }
+            Object.values(groups).forEach((group, i) => {
+                group.forEach(item => {
+                    this.data[item.id] = { item, index: i };
+                });
+            });
+        } else {
+            for (let i = 0; i < list.length; i++) {
+                this.data[list[i].id] = { item: list[i], index: i };
+            }
         }
     }
-    registerLinks(list){
-        if(!list)
+    registerLinks(list, groupByName) {
+        if (!list)
             return
-        this.link={}
-        let start=0;
-        let end=0;
-
-        for (let i=0;i<list.length;i++){
-            start=list[i].start;
-            end=list[i].end;
-            let value={link:list[i],index:i}
-            this.createAddTo(start,this.link,value,i)
-            this.createAddTo(end,this.link,value,i)
+        this.link = {}
+        let start = 0;
+        let end = 0;
+        if (groupByName) {
+            const groups = {};
+            for (let i = 0; i < list.length; i++) {
+                let item = list[i];
+                if (!item) break;
+                if (groups[item.id] !== undefined) {
+                    groups[item.id].push(item);
+                } else {
+                    groups[item.id] = [item];
+                }
+            }
+            Object.values(groups).forEach((group, i) => {
+                group.forEach(item => {
+                    start = item.start;
+                    end = item.end;
+                    let value = { link: item, index: i }
+                    this.createAddTo(start, this.link, value, i)
+                    this.createAddTo(end, this.link, value, i)
+                });
+            });
+        } else {
+            for (let i = 0; i < list.length; i++) {
+                start = list[i].start;
+                end = list[i].end;
+                let value = { link: list[i], index: i }
+                this.createAddTo(start, this.link, value, i)
+                this.createAddTo(end, this.link, value, i)
+            }
         }
     }
-    createAddTo(id,list,value,index){
+    createAddTo(id, list, value, index) {
         if (!list[id])
-            list[id]=[]
-        if (list[id].indexOf(value)==-1)
+            list[id] = []
+        if (list[id].indexOf(value) == -1)
             list[id].push(value)
     }
 
-    getTask(id){
+    getTask(id) {
         return this.data[id]
     }
-    getLinks(id){
+    getLinks(id) {
         return this.link[id]
     }
 
 }
-const instanceRegistry=new Registry();
+const instanceRegistry = new Registry();
 export default instanceRegistry;

--- a/src/lib/helpers/registry/Registry.js
+++ b/src/lib/helpers/registry/Registry.js
@@ -4,66 +4,30 @@ class Registry {
         this.link = {}
     }
 
-    registerData(list, groupByName) {
+    registerData(list) {
         if (!list)
             return;
         this.data = {}
-        if (groupByName) {
-            const groups = {};
-            for (let i = 0; i < list.length; i++) {
-                let item = list[i];
-                if (!item) break;
-                if (groups[item.name] !== undefined) {
-                    groups[item.name].push(item);
-                } else {
-                    groups[item.name] = [item];
-                }
-            }
-            Object.values(groups).forEach((group, i) => {
-                group.forEach(item => {
-                    this.data[item.id] = { item, index: i };
-                });
+        const groups = this.groupData(list, 0, list.length);
+        Object.values(groups).forEach((group, i) => {
+            group.forEach(item => {
+                this.data[item.id] = { item, index: i };
             });
-        } else {
-            for (let i = 0; i < list.length; i++) {
-                this.data[list[i].id] = { item: list[i], index: i };
-            }
-        }
+        });
     }
-    registerLinks(list, groupByName) {
+
+    registerLinks(list) {
         if (!list)
             return
         this.link = {}
         let start = 0;
         let end = 0;
-        if (groupByName) {
-            const groups = {};
-            for (let i = 0; i < list.length; i++) {
-                let item = list[i];
-                if (!item) break;
-                if (groups[item.id] !== undefined) {
-                    groups[item.id].push(item);
-                } else {
-                    groups[item.id] = [item];
-                }
-            }
-            Object.values(groups).forEach((group, i) => {
-                group.forEach(item => {
-                    start = item.start;
-                    end = item.end;
-                    let value = { link: item, index: i }
-                    this.createAddTo(start, this.link, value, i)
-                    this.createAddTo(end, this.link, value, i)
-                });
-            });
-        } else {
-            for (let i = 0; i < list.length; i++) {
-                start = list[i].start;
-                end = list[i].end;
-                let value = { link: list[i], index: i }
-                this.createAddTo(start, this.link, value, i)
-                this.createAddTo(end, this.link, value, i)
-            }
+        for (let i = 0; i < list.length; i++) {
+            start = list[i].start;
+            end = list[i].end;
+            let value = { link: list[i], index: i }
+            this.createAddTo(start, this.link, value, i)
+            this.createAddTo(end, this.link, value, i)
         }
     }
     createAddTo(id, list, value, index) {
@@ -78,6 +42,20 @@ class Registry {
     }
     getLinks(id) {
         return this.link[id]
+    }
+    groupData(list, startIndex, endIndex) {
+        const groups = {};
+        for (let i = startIndex; i < endIndex; i++) {
+            let item = list[i];
+            if (!item) break;
+            const key = item.groupName !== undefined ? item.groupName : item.id;
+            if (groups[key] !== undefined) {
+                groups[key].push(item);
+            } else {
+                groups[key] = [item];
+            }
+        }
+        return groups;
     }
 
 }


### PR DESCRIPTION
This PR adds a toggle to group by name, so that multiple items per row are possible.

By adding the groupName to the tasks, they get grouped into one row.

Let me know what you think :)

It turns this:
![image](https://user-images.githubusercontent.com/17567991/75551580-cf3e7e80-5a34-11ea-9933-b256b3f645a2.png)
into 
![image](https://user-images.githubusercontent.com/17567991/75551656-fb59ff80-5a34-11ea-969a-a27b7c601141.png)
by providing
```
groupName: 'Task'
```